### PR TITLE
fix(config): correct Redis env keys and typos in backend config

### DIFF
--- a/containers/application/backend/src/conf.ts
+++ b/containers/application/backend/src/conf.ts
@@ -5,7 +5,7 @@ export const config = {
     jwtTmpAuthSecret: process.env.JWT_TMP_AUTH_SECRET || 'r2ke4j+PYjNzpcOHtO+As1kl1uHEDF/xE+zSo6HZL9k=',
     accessTokenTtlMs: 900000, // 15min (15 * 60 * 1000)
     refreshTokenTtlMs: 86400000,  // 1day (24 * 60 * 60 * 1000)
-    issure: process.env.JWT_ISSURE || 'https://api.transcendence.42.fr',
+    issuer: process.env.JWT_ISSUER || 'https://api.transcendence.42.fr',
     audience: process.env.JWT_AUDIENCE || 'https://transcendence.42.fr',
     idp: {
       redirect_uri: process.env.REDIRECT_URI || 'https://transcendence.42.fr/auth/callback',
@@ -33,7 +33,7 @@ export const config = {
     user: {
       path: 'users',
       version: 'v1',
-      paginaiton: {
+      pagination: {
         offset: 0,
         limit: 20
       }
@@ -56,7 +56,7 @@ export const config = {
   },
   redis: {
     host: process.env.REDIS_HOST || 'ft-redis',
-    port: process.env.REDIS_HOST || '6379',
-    retries: process.env.REDIS_HOST || '3',
+    port: process.env.REDIS_PORT || '6379',
+    retries: process.env.REDIS_RETRIES || '3',
   },
 };


### PR DESCRIPTION
- Fixed Redis config to use correct env keys (REDIS_PORT, REDIS_RETRIES).
- Fixed typos: 'issuer' and 'pagination'.

## 🚀 概要 (Overview)

Redis 設定の環境変数キー修正とバックエンド設定の typo 修正を行いました。

## 関連イシュー (Related Issues)

- Closes # (関連するイシュー番号を入れる)

## 変更内容 (Changes)

- [ ] Redis の設定を正しい環境変数キー (REDIS_PORT, REDIS_RETRIES) に修正
- [ ] 'issuer' と 'pagination' の typo を修正

## テスト (Tests)

- [ ] 手動で Redis 接続を確認
- [ ] バックエンド設定を反映してアプリが起動することを確認

## スクリーンショット (Screenshots)

UI 変更なしのため省略

| Before | After |
| ------ | ----- |
|        |       |

## レビューワーへの伝達事項 (For Reviewers)

特に重点的に見てほしいのは Redis の環境変数キーが正しいかどうかです。

## チェックリスト (Checklist)

- [ ] `npm run lint` を実行し、エラーがないことを確認した
- [ ] `npm run build` が正常に完了することを確認した
- [ ] 自身のコードをセルフレビューした



