### PR TITLE
feature/makefile-edit (jini#1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ down-app:
 clean-app: # TODO: Implementation pending
 
 fclean-app:
-	@docker compose --env-file $(DOCKER_APP_ENV) -f $(APP)/compose.yml down --rmi local -v
+	@docker compose --env-file $(DOCKER_APP_ENV) -f $(APP)/compose.yml down --rmi local -v --remove-orphans
 	@rm -rf $(APP)/*/node_modules
 	@bash $(APP)/tools/hosts.sh delete
 
@@ -41,9 +41,10 @@ init-ops:
 
 up-ops: init-ops
 	@docker compose --env-file $(DOCKER_OPS_ENV) -f $(OPS)/compose.yml up --build -d --remove-orphans
-	@curl -u "elastic:changeme" \
-		-X POST "http://localhost:5601/api/saved_objects/_import" \
-		-H "kbn-xsrf: true" --form file=@containers/operation/elk/kibana/kibana_setup.ndjson
+	@curl -sf -o /dev/null -u "elastic:changeme" \
+		-X POST "http://localhost:5601/api/saved_objects/_import?overwrite=true" \
+		-H "kbn-xsrf: true" --form file=@containers/operation/elk/kibana/kibana_setup.ndjson \
+		|| echo "Warning: Kibana import failed"
 
 down-ops:
 	@docker compose --env-file $(DOCKER_OPS_ENV) -f $(OPS)/compose.yml down
@@ -51,9 +52,16 @@ down-ops:
 clean-ops: # TODO: Implementation pending
 
 fclean-ops:
-	@docker compose --env-file $(DOCKER_OPS_ENV) -f $(OPS)/compose.yml down --rmi local -v
+	@docker compose --env-file $(DOCKER_OPS_ENV) -f $(OPS)/compose.yml down --rmi local -v --remove-orphans
 
 re-ops: fclean-ops up-ops
+
+# 完全クリーンアップ（未使用のDocker リソースも削除）
+prune:
+	@echo "Pruning unused Docker resources..."
+	@docker image prune -f
+	@docker volume prune -f
+	@docker network prune -f
 
 .PHONEY:
 

--- a/containers/application/tools/auto-vault-init.sh
+++ b/containers/application/tools/auto-vault-init.sh
@@ -39,7 +39,11 @@ ensure_kv_and_secrets() {
     # Sync .env.local with ROOT_TOKEN
     if [ -n "$ROOT_TOKEN" ] && [ -f "$ENV_FILE" ]; then
         if grep -q "^VAULT_TOKEN=" "$ENV_FILE"; then
-            sed -i "s|^VAULT_TOKEN=.*|VAULT_TOKEN=$ROOT_TOKEN|" "$ENV_FILE"
+            if [[ "$OSTYPE" == "darwin"* ]]; then
+                sed -i '' "s|^VAULT_TOKEN=.*|VAULT_TOKEN=$ROOT_TOKEN|" "$ENV_FILE"
+            else
+                sed -i "s|^VAULT_TOKEN=.*|VAULT_TOKEN=$ROOT_TOKEN|" "$ENV_FILE"
+            fi
         else
             echo "VAULT_TOKEN=$ROOT_TOKEN" >> "$ENV_FILE"
         fi

--- a/containers/application/tools/certs.sh
+++ b/containers/application/tools/certs.sh
@@ -3,21 +3,31 @@
 DOMAIN_NAME=${ENV_DOMAIN_NAME:-transcendence.42.fr}
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-SCRIPT_DIR+="/../.secrets/certs"
+SECRETS_DIR="$SCRIPT_DIR/../.secrets"
+CERTS_DIR="$SECRETS_DIR/certs"
 
-sudo rm -rf $SCRIPT_DIR/../../.secrets
-mkdir -p $SCRIPT_DIR
+# 証明書が既に存在する場合はスキップ
+if [ -f "$CERTS_DIR/${DOMAIN_NAME}.crt" ] && [ -f "$CERTS_DIR/${DOMAIN_NAME}.key" ]; then
+    echo "SSL証明書は既に存在します。スキップします。"
+    exit 0
+fi
 
-echo "certs" >> $SCRIPT_DIR/../.gitignore
-echo "certs/${DOMAIN_NAME}.key" >> $SCRIPT_DIR/../.gitignore
-echo "certs/${DOMAIN_NAME}.crt" >> $SCRIPT_DIR/../.gitignore
+# .secrets ディレクトリを再作成
+sudo rm -rf "$SECRETS_DIR"
+mkdir -p "$CERTS_DIR"
+
+# .gitignore を作成（追記ではなく上書き）
+cat > "$SECRETS_DIR/.gitignore" << EOF
+*
+!.gitignore
+EOF
 
 openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
-    -keyout $SCRIPT_DIR/${DOMAIN_NAME}.key \
-    -out $SCRIPT_DIR/${DOMAIN_NAME}.crt \
+    -keyout "$CERTS_DIR/${DOMAIN_NAME}.key" \
+    -out "$CERTS_DIR/${DOMAIN_NAME}.crt" \
     -subj "/C=FR/ST=Ile-de-France/L=Paris/O=42School/OU=Inception/CN=${DOMAIN_NAME}"
 
-chmod 644 $SCRIPT_DIR/${DOMAIN_NAME}.key
-chmod 644 $SCRIPT_DIR/${DOMAIN_NAME}.crt
+chmod 644 "$CERTS_DIR/${DOMAIN_NAME}.key"
+chmod 644 "$CERTS_DIR/${DOMAIN_NAME}.crt"
 
-echo "SSL証明書と秘密鍵が '$SCRIPT_DIR' に生成されました。"
+echo "SSL証明書と秘密鍵が '$CERTS_DIR' に生成されました。"

--- a/containers/operation/compose.yml
+++ b/containers/operation/compose.yml
@@ -1,9 +1,9 @@
 x-logging: &logging
   logging:
-    driver: "json-file"
+    driver: 'json-file'
     options:
-      max-file: "10"
-      max-size: "100m"
+      max-file: '10'
+      max-size: '100m'
 
 networks:
   transcendence-network:
@@ -11,18 +11,18 @@ networks:
     external: true
 
 volumes:
- ft_certs:
-   driver: local
- ft_esdata:
-   driver: local
- ft_kibanadata:
-   driver: local
- ft_metricbeatdata:
-   driver: local
- ft_filebeatdata:
-   driver: local
- ft_logstashdata:
-   driver: local
+  ft_certs:
+    driver: local
+  ft_esdata:
+    driver: local
+  ft_kibanadata:
+    driver: local
+  ft_metricbeatdata:
+    driver: local
+  ft_filebeatdata:
+    driver: local
+  ft_logstashdata:
+    driver: local
 
 ####
 
@@ -36,16 +36,43 @@ services:
     volumes:
       - ft_certs:/usr/share/elasticsearch/config/certs
       - ./elk/setup.sh:/usr/share/elasticsearch/setup.sh
-    user: "0"
+    user: '0'
     command: bash /usr/share/elasticsearch/setup.sh
     environment:
       - ELASTIC_PASSWORD=${ELASTIC_PASSWORD}
       - KIBANA_PASSWORD=${KIBANA_PASSWORD}
     healthcheck:
-      test: ["CMD-SHELL", "[ -f config/certs/ft-elasticsearch/ft-elasticsearch.crt ]"]
+      test:
+        [
+          'CMD-SHELL',
+          '[ -f config/certs/ft-elasticsearch/ft-elasticsearch.crt ]',
+        ]
       interval: 1s
       timeout: 5s
       retries: 120
+    networks:
+      - transcendence-network
+
+  # Elasticsearch起動後にkibana_systemパスワードを設定
+  setup-passwords:
+    container_name: ft-setup-passwords
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.18.8
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    volumes:
+      - ft_certs:/usr/share/elasticsearch/config/certs:ro
+    environment:
+      - ELASTIC_PASSWORD=${ELASTIC_PASSWORD}
+      - KIBANA_PASSWORD=${KIBANA_PASSWORD}
+    command: >
+      bash -c '
+        until curl -s -X POST --cacert config/certs/ca/ca.crt -u "elastic:$${ELASTIC_PASSWORD}" -H "Content-Type: application/json" https://ft-elasticsearch:9200/_security/user/kibana_system/_password -d "{\"password\":\"$${KIBANA_PASSWORD}\"}" | grep -q "^{}"; do
+          echo "Waiting to set kibana_system password..."
+          sleep 5
+        done
+        echo "kibana_system password set!"
+      '
     networks:
       - transcendence-network
 
@@ -56,8 +83,8 @@ services:
       context: ./elk/elasticsearch
       dockerfile: Dockerfile
     depends_on:
-     setup:
-       condition: service_healthy
+      setup:
+        condition: service_completed_successfully
     volumes:
       - ft_certs:/usr/share/elasticsearch/config/certs
       - ft_esdata:/usr/share/elasticsearch/data
@@ -82,13 +109,13 @@ services:
       - transcendence-network
     mem_limit: ${ES_MEM_LIMIT}
     ulimits:
-     memlock:
-       soft: -1
-       hard: -1
+      memlock:
+        soft: -1
+        hard: -1
     healthcheck:
       test:
         [
-          "CMD-SHELL",
+          'CMD-SHELL',
           "curl -s --cacert config/certs/ca/ca.crt https://localhost:9200 | grep -q 'missing authentication credentials'",
         ]
       interval: 10s
@@ -103,12 +130,12 @@ services:
       context: ./elk/logstash
       dockerfile: Dockerfile
     depends_on:
-     elasticsearch:
-       condition: service_healthy
-     kibana:
-       condition: service_healthy
+      elasticsearch:
+        condition: service_healthy
+      kibana:
+        condition: service_healthy
     labels:
-     co.elastic.logs/module: logstash
+      co.elastic.logs/module: logstash
     networks:
       - transcendence-network
 
@@ -123,6 +150,8 @@ services:
     depends_on:
       elasticsearch:
         condition: service_healthy
+      setup-passwords:
+        condition: service_completed_successfully
     labels:
       co.elastic.logs/module: kibana
     volumes:
@@ -143,7 +172,7 @@ services:
     healthcheck:
       test:
         [
-          "CMD-SHELL",
+          'CMD-SHELL',
           "curl -s -I http://localhost:5601 | grep -q 'HTTP/1.1 302 Found'",
         ]
       interval: 10s
@@ -163,11 +192,11 @@ services:
     volumes:
       - ft_certs:/usr/share/metricbeat/certs
       - ft_metricbeatdata:/usr/share/metricbeat/data
-      - "./elk/metricbeat.yml:/usr/share/metricbeat/metricbeat.yml:ro"
-      - "/var/run/docker.sock:/var/run/docker.sock:ro"
-      - "/sys/fs/cgroup:/hostfs/sys/fs/cgroup:ro"
-      - "/proc:/hostfs/proc:ro"
-      - "/:/hostfs:ro"
+      - './elk/metricbeat.yml:/usr/share/metricbeat/metricbeat.yml:ro'
+      - '/var/run/docker.sock:/var/run/docker.sock:ro'
+      - '/sys/fs/cgroup:/hostfs/sys/fs/cgroup:ro'
+      - '/proc:/hostfs/proc:ro'
+      - '/:/hostfs:ro'
     environment:
       - ELASTIC_USER=elastic
       - ELASTIC_PASSWORD=${ELASTIC_PASSWORD}
@@ -188,10 +217,10 @@ services:
       - ft_certs:/usr/share/filebeat/certs
       - ft_filebeatdata:/usr/share/filebeat/data
       # - "./elk/filebeat_ingest_data/:/usr/share/filebeat/ingest_data/"
-      - "../application/backend/logs:/usr/share/filebeat/ingest_data:ro"
-      - "./elk/filebeat.yml:/usr/share/filebeat/filebeat.yml:ro"
-      - "/var/lib/docker/containers:/var/lib/docker/containers:ro"
-      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+      - '../application/backend/logs:/usr/share/filebeat/ingest_data:ro'
+      - './elk/filebeat.yml:/usr/share/filebeat/filebeat.yml:ro'
+      - '/var/lib/docker/containers:/var/lib/docker/containers:ro'
+      - '/var/run/docker.sock:/var/run/docker.sock:ro'
     environment:
       - ELASTIC_USER=elastic
       - ELASTIC_PASSWORD=${ELASTIC_PASSWORD}

--- a/containers/operation/elk/setup.sh
+++ b/containers/operation/elk/setup.sh
@@ -4,6 +4,12 @@ set -eu
 
 ES=ft-elasticsearch
 
+# 証明書が既に存在する場合は早期終了
+if [ -f config/certs/ft-elasticsearch/ft-elasticsearch.crt ]; then
+  echo "Certificates already exist. Skipping setup."
+  exit 0
+fi
+
 if [ x${ELASTIC_PASSWORD} == x ]; then
   echo "Set the ELASTIC_PASSWORD environment variable in the .env file";
   exit 1;
@@ -40,8 +46,4 @@ echo "Setting file permissions"
 chown -R root:root config/certs;
 find . -type d -exec chmod 750 \{\} \;;
 find . -type f -exec chmod 640 \{\} \;;
-echo "Waiting for Elasticsearch availability";
-until curl -s --cacert config/certs/ca/ca.crt https://${ES}:9200 | grep -q "missing authentication credentials"; do sleep 30; done;
-echo "Setting kibana_system password";
-until curl -s -X POST --cacert config/certs/ca/ca.crt -u "elastic:${ELASTIC_PASSWORD}" -H "Content-Type: application/json" https://${ES}:9200/_security/user/kibana_system/_password -d "{\"password\":\"${KIBANA_PASSWORD}\"}" | grep -q "^{}"; do sleep 10; done;
-echo "All done!";
+echo "Certificates ready!";


### PR DESCRIPTION
## 🚀 概要 (Overview)

Makefile周りの気になる部分を修正しました。

## 変更内容 (Changes)

- [x] fclean時に不要なイメージ残りがちなのを修正（自前ビルドは削除）
- [x] sedの挙動の違いでMacだと1行出てきちゃうのを修正
- [x] ops setupがデッドロックしてエラーになる問題を解消（たぶん）
  - setup コンテナが kibana_system のパスワードを設定するには、Elasticsearch が起動している必要がある
  しかし Elasticsearch は setup の完了を待っている → デッドロック

## チェックリスト (Checklist)

- [x] 自身のコードをセルフレビューした
