### PR TITLE
フロントエンドのビルドに対応

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,19 @@ prune:
 	@docker volume prune -f
 	@docker network prune -f
 
+# -----------------
+# PRODUCTION TARGET
+# -----------------
+prod: create-network init-app
+	@bash $(APP)/tools/certs.sh
+	@bash $(APP)/tools/gen-vault-cert.sh
+	@echo "Building frontend for production..."
+	@docker compose -f $(APP)/compose.prod.yml build frontend
+	@echo "Starting application in production mode..."
+	@docker compose --env-file $(DOCKER_APP_ENV) -f $(APP)/compose.prod.yml up -d --remove-orphans
+	@bash $(APP)/tools/auto-vault-init.sh
+	@bash $(APP)/tools/hosts.sh create
+	@ $(make) up-ops
 
 ## Application Recipes
 init-app:

--- a/containers/application/compose.prod.yml
+++ b/containers/application/compose.prod.yml
@@ -1,0 +1,172 @@
+x-logging: &logging
+  logging:
+    driver: 'json-file'
+    options:
+      max-file: '10'
+      max-size: '100m'
+
+networks:
+  transcendence-network:
+    name: transcendence-network
+    external: true
+
+volumes:
+  storage:
+    name: ft-storage
+    driver_opts:
+      type: none
+      o: bind
+      device: ${DATA_DIR}
+  vault-data:
+    name: ft-vault-data
+
+secrets:
+  nginx_certificate:
+    file: ./.secrets/certs/transcendence.42.fr.crt
+  nginx_private_key:
+    file: ./.secrets/certs/transcendence.42.fr.key
+
+####
+
+services:
+  nginx:
+    init: true
+    build:
+      context: ./nginx
+      dockerfile: Dockerfile
+    container_name: ft-nginx
+    ports:
+      - '80:8080' # REDIRECT TO HTTPS
+      - '443:8443'
+    volumes:
+      - './frontend/dist:/usr/share/nginx/html:ro'
+    networks:
+      - transcendence-network
+    secrets:
+      - nginx_certificate
+      - nginx_private_key
+    <<: *logging
+
+  frontend:
+    init: true
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+    container_name: ft-frontend
+    ports: # TODO: delete this section.
+      - '${FRONTEND_EXTERNAL_PORT:-5173}:${FRONTEND_INTERNAL_PORT:-5173}'
+    volumes:
+      - ./frontend:/app
+      - ./common:/common
+      - '/app/node_modules'
+    env_file:
+      - ./.env.local
+    networks:
+      - transcendence-network
+    <<: *logging
+
+  backend:
+    init: true
+    build:
+      context: ./backend
+      dockerfile: Dockerfile.dev
+    container_name: ft-backend
+    ports: # TODO: delete this section.
+      - '${BACKEND_EXTERNAL_PORT:-8080}:${BACKEND_INTERNAL_PORT:-8080}'
+    volumes:
+      - ./backend:/app
+      - ./common:/common
+      - storage:/var/lib/sqlite
+      - '/app/node_modules'
+    env_file:
+      - ./.env.local # TODO: 環境変数管理ファイルを分離
+    networks:
+      - transcendence-network
+    restart: unless-stopped
+    depends_on:
+      - redis
+    <<: *logging
+
+  database:
+    init: true
+    build:
+      context: ./sqlite
+      dockerfile: Dockerfile
+    container_name: ft-database
+    # ports: Planned update to PSQL
+    #   - "5432:5432"
+    volumes:
+      - storage:/var/lib/sqlite
+    networks:
+      - transcendence-network
+    restart: unless-stopped
+
+  redis:
+    init: true
+    build:
+      context: ./redis
+      dockerfile: Dockerfile
+    container_name: ft-redis
+    ports:
+      - '${REDIS_HOST_PORT:-6379}:${REDIS_CONTAINER_PORT:-6379}'
+    restart: unless-stopped
+    tty: true
+    networks:
+      - transcendence-network
+
+  vault:
+    image: hashicorp/vault:1.13.3
+    container_name: ft-vault
+    ports:
+      - '8200:8200'
+    environment:
+      VAULT_ADDR: 'https://127.0.0.1:8200'
+      VAULT_SKIP_VERIFY: 'true'
+      SKIP_SETCAP: 'true'
+    cap_add:
+      - IPC_LOCK
+    volumes:
+      - ./.secrets/certs/vault:/vault/certs:ro
+      - ./tools/vault-config-init.sh:/vault/vault-config-init.sh
+      - vault-data:/vault/data
+    entrypoint: /bin/sh
+    command:
+      - -c
+      - |
+        mkdir -p /vault/config
+        cat > /vault/config/vault.hcl << 'VAULTEOF'
+        ui = true
+        listener "tcp" {
+          address     = "0.0.0.0:8200"
+          tls_cert_file = "/vault/certs/vault.crt"
+          tls_key_file  = "/vault/certs/vault.key"
+        }
+        storage "file" {
+          path = "/vault/data"
+        }
+        api_addr = "https://127.0.0.1:8200"
+        VAULTEOF
+        exec vault server -config=/vault/config/vault.hcl
+    networks:
+      - transcendence-network
+
+  # ====================
+  # EXPORTER CONTAINERS
+  # ====================
+  nginx_exporter:
+    init: true
+    container_name: ft-nginx-exporter
+    image: nginx/nginx-prometheus-exporter:1.5.0
+    command:
+      - -nginx.scrape-uri=http://ft-nginx:8081/stub_status
+    networks:
+      - transcendence-network
+
+  redis_exporter:
+    init: true
+    container_name: ft-redis-exporter
+    image: oliver006/redis_exporter:v1.80.0-alpine
+    command:
+      - '--redis.addr=redis://redis:6379'
+    networks:
+      - transcendence-network

--- a/containers/application/frontend/Dockerfile
+++ b/containers/application/frontend/Dockerfile
@@ -1,34 +1,13 @@
 # -----------------
-# 1. BUILD STAGE
+# BUILD HTML
 # -----------------
 FROM node:22-alpine AS builder
 
 WORKDIR /app
 
 COPY package*.json ./
-
 RUN npm install
 
 COPY . .
 
-RUN npm run build
-
-
-# -----------------
-# 2. PRD STAGE
-# -----------------
-FROM node:22-alpine
-
-ENV NODE_ENV=production
-
-WORKDIR /app
-
-COPY --from=builder /app/package*.json ./
-
-RUN npm install --omit=dev
-
-COPY --from=builder /app/dist ./dist
-
-EXPOSE 8080
-
-CMD [ "node", "dist/main.js" ]
+CMD ["npm", "run", "build"]


### PR DESCRIPTION
## 🚀 概要 (Overview)
- フロントエンドコンテナがviteサーバーをうごかしつづけていたので、ビルドした成果物を配布するように変更
- make prod で起動可能（追加）

## 関連イシュー (Related Issues)

- Closes #86 

<img width="1047" height="680" alt="スクリーンショット 2026-01-28 23 13 01" src="https://github.com/user-attachments/assets/4278bc16-6e1b-4dea-b392-b898bf56530f" />
